### PR TITLE
Fixed palette bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "demosaur",
+  "name": "a-app-react",
   "version": "1.1.0",
-  "homepage": "/demosaur",
+  "homepage": "/a-app-react",
   "private": true,
   "dependencies": {
     "@material-ui/core": "^4.11.0",

--- a/public/index.html
+++ b/public/index.html
@@ -24,7 +24,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>Demosaur</title>
+    <title>a-app-react</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/src/appcontainer/pages/settings.jsx
+++ b/src/appcontainer/pages/settings.jsx
@@ -20,7 +20,7 @@ import Header from "../Header";
 import Content from "../Content";
 import BackIconButton from "../BackIconButton";
 
-import { usePalette, str2color } from "../usePalette";
+import { usePalette, str2color } from "../../usePalette";
 
 function Component() {
   const [
@@ -29,6 +29,7 @@ function Component() {
     setSecondary,
     setType
   ] = usePalette();
+
   const [open, setOpen] = useState(false);
 
   const handleToggleTheme = () => setType(type === "light" ? "dark" : "light");

--- a/src/appcontainer/usePalette.js
+++ b/src/appcontainer/usePalette.js
@@ -1,3 +1,5 @@
+// TODO: This file is no loger needed
+
 import { createContext, useContext } from "react";
 
 import amber from "@material-ui/core/colors/amber";
@@ -17,7 +19,7 @@ import red from "@material-ui/core/colors/red";
 import teal from "@material-ui/core/colors/teal";
 import yellow from "@material-ui/core/colors/yellow";
 
-const PaletteContext = createContext({
+export const PaletteContext = createContext({
   primary: "teal",
   secondary: "teal",
   type: "light"

--- a/src/usePalette.js
+++ b/src/usePalette.js
@@ -17,11 +17,16 @@ import red from "@material-ui/core/colors/red";
 import teal from "@material-ui/core/colors/teal";
 import yellow from "@material-ui/core/colors/yellow";
 
-export const PaletteContext = createContext({
-  primary: "teal",
-  secondary: "teal",
-  type: "light"
-});
+export const PaletteContext = createContext([
+  {
+    primary: "teal",
+    secondary: "teal",
+    type: "light"
+  },
+  () => {},
+  () => {},
+  () => {}
+]);
 
 export function usePalette() {
   return useContext(PaletteContext);


### PR DESCRIPTION
File **App.jsx** and **settings.jsx** did import two different files:

* **src/usePalette.js**
* **src/appcontainer/usePalette.js**

There was a mix of problems here:

* **src/appcontainer/usePalette.js** didn't export `Context`
* **settings.jsx** was using the default context, that was wrong (and throw the error)

I fixed the issues:

* both file import from **src/usePalette.jsx**
* the default context has the right shape 